### PR TITLE
Changed false version of Firefox in first tabular

### DIFF
--- a/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
+++ b/files/en-us/web/http/content_negotiation/list_of_default_accept_values/index.md
@@ -17,7 +17,7 @@ These are the values sent when the context doesn't give better information. Note
 
 | User Agent                 | Value                                                                                                                                                                   |
 | -------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Firefox 91 and later [1]   | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                                                                 |
+| Firefox 92 and later [1]   | `text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,*/*;q=0.8`                                                                                 |
 | Firefox 72 to 91 [1]       | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                                                            |
 | Firefox 66 to 71 [1]       | `text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8`                                                                                                       |
 | Firefox 65 [1]             | `text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8`                                                                                            |


### PR DESCRIPTION
> What was wrong/why is this fix needed? (quick summary only)
The header in the first row of the first tabular is actually only applied to Firefox 92 or greater, as correctly stated in the lower "Values for an image" section.